### PR TITLE
Proxy-only mode: allowing processes with no commands, + default port

### DIFF
--- a/lib/invoker/power/url_rewriter.rb
+++ b/lib/invoker/power/url_rewriter.rb
@@ -1,8 +1,11 @@
 module Invoker
   module Power
     class UrlRewriter
+      DEFAULT_PROCESS_NAME = "default"
+
       def select_backend_config(complete_path)
         possible_matches = extract_host_from_domain(complete_path)
+        possible_matches.push(DEFAULT_PROCESS_NAME)
         exact_match = nil
         possible_matches.each do |match|
           if match

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -13,7 +13,7 @@ module Invoker
     end
 
     def start_process(process_info)
-      return if process_info[:cmd].nil?
+      return if process_info.cmd.nil?
 
       m, s = PTY.open
       s.raw! # disable newline conversion.

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -13,15 +13,15 @@ module Invoker
     end
 
     def start_process(process_info)
+      return if process_info[:cmd].nil?
+
       m, s = PTY.open
       s.raw! # disable newline conversion.
 
       pid = run_command(process_info, s)
-
       s.close
 
       worker = CommandWorker.new(process_info.label, m, pid, select_color)
-
       add_worker(worker)
       wait_on_pid(process_info.label, pid)
     end
@@ -105,6 +105,7 @@ module Invoker
 
     def kill_workers
       @workers.each do |key, worker|
+        next if worker.pid.nil?
         kill_or_remove_process(worker.pid, "INT", worker.command_label)
       end
       @workers = {}

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -105,7 +105,6 @@ module Invoker
 
     def kill_workers
       @workers.each do |key, worker|
-        next if worker.pid.nil?
         kill_or_remove_process(worker.pid, "INT", worker.command_label)
       end
       @workers = {}

--- a/spec/invoker/power/url_rewriter_spec.rb
+++ b/spec/invoker/power/url_rewriter_spec.rb
@@ -3,67 +3,106 @@ require 'spec_helper'
 describe Invoker::Power::UrlRewriter do
   let(:rewriter) { Invoker::Power::UrlRewriter.new }
 
-  context "matching domain part of incoming request" do
-    before(:all) do
-      @original_invoker_config = Invoker.config
+  before(:all) do
+    @original_invoker_config = Invoker.config
 
-      Invoker.config = mock
-      Invoker.config.stubs(:tld).returns("dev")
+    Invoker.config = mock
+    Invoker.config.stubs(:tld).returns("dev")
+  end
+
+  after(:all) do
+    Invoker.config = @original_invoker_config
+  end
+
+  def dns_check_result(process_name, port)
+    OpenStruct.new(ip: "0.0.0.0", port: port, process_name: process_name)
+  end
+
+  describe "#select_backend_config" do
+    context "match exists in the config" do
+      it "should return it" do
+        match = dns_check_result("foo", 3000)
+        rewriter.expects(:dns_check).with(:process_name => "foo").returns(match)
+        expect(rewriter.select_backend_config("foo.dev").port).to eq(3000)
+      end
     end
 
-    after(:all) do
-      Invoker.config = @original_invoker_config
-    end
-
-    it "should match foo.dev" do
-      match = rewriter.extract_host_from_domain("foo.dev")
-      expect(match).to_not be_empty
-
-      matching_string = match[0]
-      expect(matching_string).to eq("foo")
-    end
-
-    it "should match foo.dev:1080" do
-      match = rewriter.extract_host_from_domain("foo.dev:1080")
-      expect(match).to_not be_empty
-
-      matching_string = match[0]
-      expect(matching_string).to eq("foo")
-    end
-
-    it "should match emacs.bar.dev" do
-      match = rewriter.extract_host_from_domain("emacs.bar.dev")
-      expect(match).to_not be_empty
-
-      expect(match[0]).to eq("emacs.bar")
-      expect(match[1]).to eq("bar")
-    end
-
-    it "should match hello-world.dev" do
-      match = rewriter.extract_host_from_domain("hello-world.dev")
-      expect(match).to_not be_nil
-
-      expect(match[0]).to eq("hello-world")
-    end
-
-    context 'user sets up a custom top level domain' do
-      before(:all) do
-        @original_invoker_config = Invoker.config
-
-        Invoker.config = mock
-        Invoker.config.stubs(:tld).returns("local")
+    context "no match in the config" do
+      context "no default" do
+        it "should return an empty match" do
+          match = dns_check_result("foo", nil)
+          default = dns_check_result("default", nil)
+          rewriter.stubs(:dns_check).with(:process_name => "foo").returns(match)
+          rewriter.stubs(:dns_check).with(:process_name => "default").returns(default)
+          expect(rewriter.select_backend_config("foo.dev").port).to eq(nil)
+        end
       end
 
-      it 'should match domain part of incoming request correctly' do
-        match = rewriter.extract_host_from_domain("foo.local")
+      context "with default" do
+        it "should return it" do
+          match = dns_check_result("foo", nil)
+          default = dns_check_result("default", 3000)
+          rewriter.stubs(:dns_check).with(:process_name => "foo").returns(match)
+          rewriter.stubs(:dns_check).with(:process_name => "default").returns(default)
+          expect(rewriter.select_backend_config("foo.dev").port).to eq(3000)
+        end
+      end
+    end
+  end
+
+  describe "#extract_host_from_domain" do
+    context "matching domain part of incoming request" do
+
+      it "should match foo.dev" do
+        match = rewriter.extract_host_from_domain("foo.dev")
         expect(match).to_not be_empty
 
         matching_string = match[0]
         expect(matching_string).to eq("foo")
       end
 
-      after(:all) do
-        Invoker.config = @original_invoker_config
+      it "should match foo.dev:1080" do
+        match = rewriter.extract_host_from_domain("foo.dev:1080")
+        expect(match).to_not be_empty
+
+        matching_string = match[0]
+        expect(matching_string).to eq("foo")
+      end
+
+      it "should match emacs.bar.dev" do
+        match = rewriter.extract_host_from_domain("emacs.bar.dev")
+        expect(match).to_not be_empty
+
+        expect(match[0]).to eq("emacs.bar")
+        expect(match[1]).to eq("bar")
+      end
+
+      it "should match hello-world.dev" do
+        match = rewriter.extract_host_from_domain("hello-world.dev")
+        expect(match).to_not be_nil
+
+        expect(match[0]).to eq("hello-world")
+      end
+
+      context 'user sets up a custom top level domain' do
+        before(:all) do
+          @original_invoker_config = Invoker.config
+
+          Invoker.config = mock
+          Invoker.config.stubs(:tld).returns("local")
+        end
+
+        it 'should match domain part of incoming request correctly' do
+          match = rewriter.extract_host_from_domain("foo.local")
+          expect(match).to_not be_empty
+
+          matching_string = match[0]
+          expect(matching_string).to eq("foo")
+        end
+
+        after(:all) do
+          Invoker.config = @original_invoker_config
+        end
       end
     end
   end

--- a/spec/invoker/process_manager_spec.rb
+++ b/spec/invoker/process_manager_spec.rb
@@ -3,6 +3,15 @@ require "spec_helper"
 describe Invoker::ProcessManager do
   let(:process_manager) { Invoker::ProcessManager.new }
 
+  describe "#start_process" do
+    it "should work with no command" do
+      process = OpenStruct.new(:label => "resque", :dir => "bar")
+      invoker_config.stubs(:processes).returns([process])
+      invoker_config.expects(:process).returns(process)
+      process_manager.start_process(process)
+    end
+  end
+
   describe "#start_process_by_name" do
     it "should find command by label and start it, if found" do
       @original_invoker_config = Invoker.config

--- a/spec/invoker/process_manager_spec.rb
+++ b/spec/invoker/process_manager_spec.rb
@@ -7,7 +7,6 @@ describe Invoker::ProcessManager do
     it "should work with no command" do
       process = OpenStruct.new(:label => "resque", :dir => "bar")
       invoker_config.stubs(:processes).returns([process])
-      invoker_config.expects(:process).returns(process)
       process_manager.start_process(process)
     end
   end

--- a/spec/invoker/process_manager_spec.rb
+++ b/spec/invoker/process_manager_spec.rb
@@ -3,10 +3,19 @@ require "spec_helper"
 describe Invoker::ProcessManager do
   let(:process_manager) { Invoker::ProcessManager.new }
 
+  before(:all) do
+    @original_invoker_config = Invoker.config
+    Invoker.config = mock
+  end
+
+  after(:all) do
+    Invoker.config = @original_invoker_config
+  end
+
   describe "#start_process" do
     it "should work with no command" do
       process = OpenStruct.new(:label => "resque", :dir => "bar")
-      invoker_config.stubs(:processes).returns([process])
+      Invoker.config.stubs(:processes).returns([process])
       process_manager.start_process(process)
     end
   end


### PR DESCRIPTION
In some cases, you want to run your processes manually instead of relying on Invoker. These (minor) changes allow Invoker to be started with a config file defining such processes. In this case, no processes get spawn by Invoker but the DNS / port-proxying part works as expected.

Example of a now valid config file:

```
[ruby-app]
port = 3000

[some-node-app]
port = 9001
```

You may also add a default config which will redirect any domain.dev to the specified port:

```
[default]
port = 3000
```
