### PR TITLE
Make compliant for Ruby 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.0.0
+* Updated to make compliant for > Ruby 3.0, updated http-parser-lite reference, fixed exists? vs exist? deprecation. (https://github.com/codemancers/invoker/pull/250)
+
 # v1.5.8
 * Add `--wait` / `-w` option to `invoker list` to stream updates instead of printing once & exiting (https://github.com/code-mancers/invoker/pull/239)
 * Make `Host` header check case-insensitive (https://github.com/code-mancers/invoker/pull/241)

--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency("em-proxy", "~> 0.1")
   s.add_dependency("rubydns", "~> 0.8.5")
   s.add_dependency("uuid", "~> 2.3")
-  s.add_dependency("http-parser-lite", "~> 1.0.1")
+  s.add_dependency("http-parser-lite", "~> 1.0")
   s.add_dependency("dotenv", "~> 2.0", "!= 2.3.0", "!= 2.4.0")
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("mocha")

--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency("em-proxy", "~> 0.1")
   s.add_dependency("rubydns", "~> 0.8.5")
   s.add_dependency("uuid", "~> 2.3")
-  s.add_dependency("http-parser-lite", "~> 0.6")
+  s.add_dependency("http-parser-lite", "~> 1.0.1")
   s.add_dependency("dotenv", "~> 2.0", "!= 2.3.0", "!= 2.4.0")
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("mocha")

--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.version = Invoker::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.required_ruby_version = '>= 3.0.0'
   s.authors = ["Hemant Kumar", "Amitava Basak"]
   s.description = %q{Something small for process management}
   s.email = %q{hemant@codemancers.com}

--- a/lib/invoker.rb
+++ b/lib/invoker.rb
@@ -94,7 +94,7 @@ module Invoker
 
     def run_without_bundler
       if defined?(Bundler)
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           yield
         end
       else

--- a/lib/invoker/daemon.rb
+++ b/lib/invoker/daemon.rb
@@ -13,7 +13,7 @@ module Invoker
         Invoker::Logger.puts "Invoker daemon is already running"
         exit(0)
       elsif dead?
-        File.delete(pid_file) if File.exists?(pid_file)
+        File.delete(pid_file) if File.exist?(pid_file)
       end
       Invoker::Logger.puts "Running Invoker daemon"
       daemonize

--- a/lib/invoker/power/http_response.rb
+++ b/lib/invoker/power/http_response.rb
@@ -52,7 +52,7 @@ module Invoker
       end
 
       def use_file_as_body(file_name)
-        if file_name && File.exists?(file_name)
+        if file_name && File.exist?(file_name)
           file_content = File.read(file_name)
           self.body = file_content
         else

--- a/lib/invoker/power/setup.rb
+++ b/lib/invoker/power/setup.rb
@@ -56,7 +56,7 @@ module Invoker
       end
 
       def check_if_setup_can_run?
-        !File.exists?(Invoker::Power::Config.config_file)
+        !File.exist?(Invoker::Power::Config.config_file)
       end
 
       def create_config_file
@@ -86,7 +86,7 @@ module Invoker
       end
 
       def safe_remove_file(file)
-        File.delete(file) if File.exists?(file)
+        File.delete(file) if File.exist?(file)
       end
     end
   end

--- a/lib/invoker/version.rb
+++ b/lib/invoker/version.rb
@@ -43,5 +43,5 @@ module Invoker
       Version.new(next_splits.join('.'))
     end
   end
-  VERSION = "1.6.0"
+  VERSION = "2.0.0"
 end

--- a/lib/invoker/version.rb
+++ b/lib/invoker/version.rb
@@ -43,5 +43,5 @@ module Invoker
       Version.new(next_splits.join('.'))
     end
   end
-  VERSION = "1.5.8"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
Updated http-parser-lite gem to Ruby 3.3 compliant gem.
Removed deprecations / errors around the removal of exists? in Ruby 3.2
Closes #249
Closes #242 